### PR TITLE
Add client logging and fix null pointer issue in nodeLocator

### DIFF
--- a/client/src/main/java/edu/scu/coen317/client/DynamoClient.java
+++ b/client/src/main/java/edu/scu/coen317/client/DynamoClient.java
@@ -37,6 +37,7 @@ public class DynamoClient {
             ClientResponse resp = execute(req);
             LOG.info("PUT request {}", resp != null ? "succeeded" : "failed");
         } catch (Exception e) {
+            e.printStackTrace();
             LOG.warn("PUT request got interrupted...");
         }
     }
@@ -49,6 +50,7 @@ public class DynamoClient {
             LOG.info("GET request {}", resp != null ? "succeeded" : "failed");
             return resp.getVal();
         } catch (Exception e) {
+            e.printStackTrace();
             LOG.warn("GET request got interrupted...");
         }
         return "";
@@ -73,9 +75,11 @@ public class DynamoClient {
 
             Set<Node> targets = NodeLocator.getNodes(NodeGlobalView.readAll(), req.getKey(), "");
             for (Node node : targets) {
+                LOG.debug("Sending client request to {} {}", node.getIp(), node.getPort());
                 ChannelFuture future = b.connect(node.getIp(), node.getPort()).await();
                 future.channel().closeFuture().sync();
                 if (future.isSuccess()) {
+                    LOG.debug("Client request to {} {} succeeded", node.getIp(), node.getPort());
                     return handler.getResponse();
                 }
             }

--- a/common/src/main/java/edu/scu/coen317/common/util/NodeLocator.java
+++ b/common/src/main/java/edu/scu/coen317/common/util/NodeLocator.java
@@ -14,9 +14,11 @@ public class NodeLocator {
     public static Set<Node> getNodes(ConcurrentSkipListSet<Node> members, String key, String selfHash) {
         Set<Node> nodes = new HashSet<>();
         String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
-
         Node tmp = new Node("", 0, HashFunctions.md5Hash(key), Integer.valueOf(pid));
         Node start = members.ceiling(tmp);
+        if (start == null) {
+            start = members.first();
+        }
         Set<Node> tailSet = members.tailSet(start, true);
 
         // get N replicas from members list


### PR DESCRIPTION
When the hash of key is larger than the last node, `members.ceiling(tmp)` will return `null`. Fix to return the first node instead.